### PR TITLE
target/ppc/spapr: Add H-Call H_GET_CPU_CHARACTERISTICS

### DIFF
--- a/include/hw/ppc/spapr.h
+++ b/include/hw/ppc/spapr.h
@@ -320,6 +320,7 @@ struct sPAPRMachineState {
 #define H_GET_HCA_INFO          0x1B8
 #define H_GET_PERF_COUNT        0x1BC
 #define H_MANAGE_TRACE          0x1C0
+#define H_GET_CPU_CHARACTERISTICS 0x1C8
 #define H_FREE_LOGICAL_LAN_BUFFER 0x1D4
 #define H_QUERY_INT_STATE       0x1E4
 #define H_POLL_PENDING          0x1D8


### PR DESCRIPTION
The new H-Call H_GET_CPU_CHARACTERISTICS is used by the guest to query
behaviours and available characteristics of the cpu.

Implement the handler for this new H-Call which formulates its response
based on the host capabilities.

Signed-off-by: Suraj Jitindar Singh <sjitindarsingh@gmail.com>

Manually backported from c59704b254734182c3202e0c261589ea2ccf485e
upstream because it doesn't apply cleanly.

Signed-off-by: Jose Ricardo Ziviani <joserz@linux.vnet.ibm.com>
Signed-off-by: Ricardo M. Matinata <rmm@br.ibm.com>