### PR TITLE
target-ppc: Handle additional bits in H_GET_CPU_CHARACTERISTICS

### DIFF
--- a/target-ppc/kvm_ppc.h
+++ b/target-ppc/kvm_ppc.h
@@ -54,9 +54,8 @@ void kvmppc_hash64_free_pteg(uint64_t token);
 void kvmppc_hash64_write_pte(CPUPPCState *env, target_ulong pte_index,
                              target_ulong pte0, target_ulong pte1);
 bool kvmppc_has_cap_fixup_hcalls(void);
-int kvmppc_get_cap_safe_cache(void);
-int kvmppc_get_cap_safe_bounds_check(void);
-int kvmppc_get_cap_safe_indirect_branch(void);
+uint64_t kvmppc_get_cap_ppc_cpu_char_character(void);
+uint64_t kvmppc_get_cap_ppc_cpu_char_behaviour(void);
 int kvmppc_enable_hwrng(void);
 int kvmppc_put_books_sregs(PowerPCCPU *cpu);
 PowerPCCPUClass *kvm_ppc_get_host_cpu_class(void);
@@ -247,19 +246,14 @@ static inline bool kvmppc_has_cap_fixup_hcalls(void)
     abort();
 }
 
-static inline int kvmppc_get_cap_safe_cache(void)
+static inline uint64_t kvmppc_get_cap_ppc_cpu_char_character(void)
 {
-    return 0;
+    return 0ULL;
 }
 
-static inline int kvmppc_get_cap_safe_bounds_check(void)
+static inline uint64_t kvmppc_get_cap_ppc_cpu_char_behaviour(void)
 {
-    return 0;
-}
-
-static inline int kvmppc_get_cap_safe_indirect_branch(void)
-{
-    return 0;
+    return 0ULL;
 }
 
 static inline int kvmppc_enable_hwrng(void)


### PR DESCRIPTION
The hcall H_GET_CPU_CHARACTERISTICS is used by the guest to determine
information about the required behaviours and available characteristics
of the cpu.

Bits may be added to this hcall, the information for which is queried
from the hypervisor using the KVM_PPC_GET_CPU_CHAR ioctl. In order to
handle the case where additional bits may be added to this hcall, and
thus to the ioctl, relax the parsing in qemu so that there is minimal
modification of the data before it is passed to the guest.

Signed-off-by: Suraj Jitindar Singh <sjitindarsingh@gmail.com>
Signed-off-by: Ricardo M. Matinata <rmm@br.ibm.com>